### PR TITLE
change cytonorm and cycombine clustering to use lineage markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 
 * Implemented function for writing FCS files from an anndata object (PR #49).
 
+* Changed cytonorm and cycombine clustering to use lineage markers (PR #54).
+
 ## BUGFIXES
 
 * Change n_inconsistent_peaks output to float and add R2 to main.nf (PR #40).

--- a/src/methods/cycombine_nocontrols/script.R
+++ b/src/methods/cycombine_nocontrols/script.R
@@ -3,8 +3,8 @@ requireNamespace("cyCombine", quietly = TRUE)
 
 ## VIASH START
 par <- list(
-  input = "resources_test/task_cyto_batch_integration/cyto_spleen_subset/unintegrated_censored.h5ad",
-  output = "resources_test/task_cyto_batch_integration/cyto_spleen_subset/output.h5ad"
+    input = "resources_test/task_cyto_batch_integration/cyto_spleen_subset/unintegrated_censored.h5ad",
+    output = "resources_test/task_cyto_batch_integration/output.h5ad"
 )
 meta <- list(name = "cycombine")
 ## VIASH END
@@ -18,42 +18,70 @@ adata_to_correct <- input_adata[, input_adata$var$to_correct]
 
 markers_to_correct <- input_adata$var_names[input_adata$var$to_correct]
 
+lineage_markers <- as.vector(input_adata$var_names[input_adata$var$marker_type == "lineage"])
+
 df_to_correct <- as.data.frame(
-  adata_to_correct$layers[["preprocessed"]],
-  check.names=FALSE
+    adata_to_correct$layers[["preprocessed"]],
+    check.names = FALSE
 )
 df_to_correct$batch <- adata_to_correct$obs$batch
 df_to_correct$sample <- adata_to_correct$obs$sample
 
 cat("Run cyCombine\n")
-df_corrected <- cyCombine::batch_correct(
-  df = df_to_correct,
-  seed = 42,
-  markers = markers_to_correct
+
+# use the default parameters in normalize
+# do the normalisation on all markers to be corrected
+df_to_correct_norm <- cyCombine::normalize(
+    df = df_to_correct,
+    markers = markers_to_correct,
+    norm_method = "scale",
+    ties.method = "average"
+)
+
+# again, using default parameter values
+cluster_labels <- cyCombine::create_som(
+    df = df_to_correct_norm,
+    markers = lineage_markers,
+    rlen = 10,
+    seed = 42,
+    xdim = 8,
+    ydim = 8
+)
+
+# Batch correct using default parameter values
+df_corrected <- cyCombine::correct_data(
+    df = df_to_correct_norm,
+    label = cluster_labels,
+    markers = markers_to_correct,
+    method = "ComBat",
+    covar = NULL,
+    anchor = NULL,
+    ref.batch = NULL,
+    parametric = TRUE
 )
 
 cat("Preparing output Anndata\n")
 df_not_corrected <- as.data.frame(
-  input_adata[, !input_adata$var$to_correct]$layers[["preprocessed"]]
+    input_adata[, !input_adata$var$to_correct]$layers[["preprocessed"]]
 )
 
 df_output <- cbind(
-  df_corrected[, markers_to_correct],
-  df_not_corrected
+    df_corrected[, markers_to_correct],
+    df_not_corrected
 )
 
 # reorder column to match input_adata
 df_output <- df_output[, input_adata$var_names]
 
 output <- anndata::AnnData(
-  obs = input_adata$obs[, integer(0)],
-  var = input_adata$var[colnames(df_output), integer(0)],
-  layers = list(integrated = df_output),
-  uns = list(
-    dataset_id = input_adata$uns$dataset_id,
-    method_id = meta$name,
-    parameters = list()
-  )
+    obs = input_adata$obs[, integer(0)],
+    var = input_adata$var[colnames(df_output), integer(0)],
+    layers = list(integrated = as.matrix(df_output)),
+    uns = list(
+        dataset_id = input_adata$uns$dataset_id,
+        method_id = meta$name,
+        parameters = list()
+    )
 )
 
 cat("Write output AnnData to file\n")

--- a/src/methods/cytonorm_controls/script.R
+++ b/src/methods/cytonorm_controls/script.R
@@ -10,7 +10,8 @@ par <- list(
 )
 meta <- list(
     name = "cytonorm_control",
-    temp_dir = "resources_test/task_cyto_batch_integration/tmp"
+    temp_dir = "resources_test/task_cyto_batch_integration/tmp",
+    resources_dir = "src/utils"
 )
 ## VIASH ENDs
 
@@ -23,7 +24,7 @@ adata <- anndata::read_h5ad(par[["input"]])
 
 # get the control samples to be used for training the model
 fset_train <- anndata_to_fcs(adata[adata$obs$is_control != 0, ])
-# every sample, including the controls, pretty much the entire unintegrated data 
+# every sample, including the controls, pretty much the entire unintegrated data
 # will be corrected.
 fset_all <- anndata_to_fcs(adata)
 
@@ -33,6 +34,8 @@ batch_lab_train <- sapply(sampleNames(fset_train), function(samp) {
 })
 
 markers_to_correct <- as.vector(adata$var$channel[adata$var$to_correct])
+
+lineage_markers <- as.vector(adata$var$channel[adata$var$marker_type == "lineage"])
 
 # FlowSOM.params and normParams are the default parameters in cytonorm
 model <- CytoNorm.train(
@@ -45,7 +48,8 @@ model <- CytoNorm.train(
         xdim = 15,
         ydim = 15,
         nClus = 10,
-        scale = FALSE
+        scale = FALSE,
+        colsToUse = lineage_markers
     ),
     transformList = NULL,
     normParams = list(nQ = 99, goal = "mean"),


### PR DESCRIPTION
## Describe your changes

Changed clustering in cytonorm and cycombine to use lineage markers instead of all markers that are to be corrected.

## Checklist before requesting a review
- [X] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [X] Minor changes
  - [ ] Bug fixes

- [X] Proposed changes are described in the CHANGELOG.md

- [X] CI Tests succeed and look good!