### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/no_integration/config.vsh.yaml
+++ b/src/control_methods/no_integration/config.vsh.yaml
@@ -14,7 +14,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/perfect_integration_horizontal/config.vsh.yaml
+++ b/src/control_methods/perfect_integration_horizontal/config.vsh.yaml
@@ -32,7 +32,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners:
   # This platform allows running the component natively

--- a/src/control_methods/perfect_integration_vertical/config.vsh.yaml
+++ b/src/control_methods/perfect_integration_vertical/config.vsh.yaml
@@ -34,7 +34,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners:
   # This platform allows running the component natively

--- a/src/control_methods/shuffle_integration/config.vsh.yaml
+++ b/src/control_methods/shuffle_integration/config.vsh.yaml
@@ -9,7 +9,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/shuffle_integration_by_batch/config.vsh.yaml
+++ b/src/control_methods/shuffle_integration_by_batch/config.vsh.yaml
@@ -9,7 +9,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/shuffle_integration_by_cell_type/config.vsh.yaml
+++ b/src/control_methods/shuffle_integration_by_cell_type/config.vsh.yaml
@@ -9,7 +9,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/data_processors/process_dataset/config.vsh.yaml
+++ b/src/data_processors/process_dataset/config.vsh.yaml
@@ -8,7 +8,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners:
   - type: executable

--- a/src/methods/combat/config.vsh.yaml
+++ b/src/methods/combat/config.vsh.yaml
@@ -34,7 +34,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [scanpy, anndata, numpy]

--- a/src/methods/cycombine_nocontrols/config.vsh.yaml
+++ b/src/methods/cycombine_nocontrols/config.vsh.yaml
@@ -26,7 +26,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:

--- a/src/methods/cytonorm_controls/config.vsh.yaml
+++ b/src/methods/cytonorm_controls/config.vsh.yaml
@@ -44,7 +44,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:

--- a/src/methods/gaussnorm/config.vsh.yaml
+++ b/src/methods/gaussnorm/config.vsh.yaml
@@ -41,7 +41,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: [ flowStats, flowCore, Biobase ]

--- a/src/methods/harmonypy/config.vsh.yaml
+++ b/src/methods/harmonypy/config.vsh.yaml
@@ -21,7 +21,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [anndata,harmonypy]

--- a/src/methods/limma_remove_batch_effect/config.vsh.yaml
+++ b/src/methods/limma_remove_batch_effect/config.vsh.yaml
@@ -22,7 +22,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: limma

--- a/src/metrics/average_batch_r2/config.vsh.yaml
+++ b/src/metrics/average_batch_r2/config.vsh.yaml
@@ -119,7 +119,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     # setup:

--- a/src/metrics/emd/config.vsh.yaml
+++ b/src/metrics/emd/config.vsh.yaml
@@ -282,7 +282,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:

--- a/src/metrics/flowsom_mapping_similarity/config.vsh.yaml
+++ b/src/metrics/flowsom_mapping_similarity/config.vsh.yaml
@@ -71,7 +71,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: [FlowSOM, flowCore]

--- a/src/metrics/n_inconsistent_peaks/config.vsh.yaml
+++ b/src/metrics/n_inconsistent_peaks/config.vsh.yaml
@@ -78,7 +78,7 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     # setup:


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.