### PR TITLE
Fix bug in yaml where anndata is not listed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,3 +136,7 @@
 
 * Fix unparseable characters in EMD metrics (PR #87).
 
+* Fix missing anndata in yaml file and set the base_r docker image version to 1 instead of 1.0.0 (PR #89).
+
+
+

--- a/src/methods/batchadjust_all_controls/config.vsh.yaml
+++ b/src/methods/batchadjust_all_controls/config.vsh.yaml
@@ -70,13 +70,13 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:
       - type: r
         bioc: [flowCore]
-        packages: [docstring]
+        packages: [docstring, anndata]
 
 runners:
   # This platform allows running the component natively

--- a/src/methods/batchadjust_one_control/config.vsh.yaml
+++ b/src/methods/batchadjust_one_control/config.vsh.yaml
@@ -70,13 +70,13 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:
       - type: r
         bioc: [flowCore]
-        packages: [docstring]
+        packages: [docstring, anndata]
 
 runners:
   # This platform allows running the component natively

--- a/src/methods/mnn/config.vsh.yaml
+++ b/src/methods/mnn/config.vsh.yaml
@@ -91,12 +91,13 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     # Add custom dependencies here (optional). For more information, see
     # https://viash.io/reference/config/engines/docker/#setup .
     setup:
       - type: r
         bioc: [batchelor]
+        packages: [anndata]
 
 runners:
   # This platform allows running the component natively

--- a/src/metrics/cms/config.vsh.yaml
+++ b/src/metrics/cms/config.vsh.yaml
@@ -101,10 +101,10 @@ resources:
 engines:
   # Specifications for the Docker image for this component.
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
-        packages: [robustbase, hdf5r]
+        packages: [robustbase, hdf5r, anndata]
         bioc: [CellMixS, SingleCellExperiment, Biocparallel]
         github: [scverse/anndataR]
 


### PR DESCRIPTION
## Describe your changes

Missing `anndata` in yaml file and set the `base_r` docker image version to 1 instead of 1.0.0

## Checklist before requesting a review
- [X] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [X] Bug fixes

- [X] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!