### PR TITLE
Restore the original cell order after the FCS roundtrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@
 
 * Update flowsom mapping similarity so we subset to just markers to correct, and lisi to remove control samples
   and unlabelled cells (PR #119).
+
 * Fix bug in `gaussnorm` and the `cytonorm_*` methods where the batch corrected matrix was
   attached to the obs of the input anndata while still being ordered per sample (PR #128).
   Added `fcs_cell_order()` to `src/utils/anndata_to_fcs.R` to restore the original cell order.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,3 +240,6 @@
 
 * Update flowsom mapping similarity so we subset to just markers to correct, and lisi to remove control samples
   and unlabelled cells (PR #119).
+* Fix bug in `gaussnorm` and the `cytonorm_*` methods where the batch corrected matrix was
+  attached to the obs of the input anndata while still being ordered per sample (PR #128).
+  Added `fcs_cell_order()` to `src/utils/anndata_to_fcs.R` to restore the original cell order.

--- a/src/methods/cytonorm_all_controls_to_goal/script.R
+++ b/src/methods/cytonorm_all_controls_to_goal/script.R
@@ -114,6 +114,17 @@ cat("Preparing output anndata\n")
 norm_mat <- flowCore::fsApply(norm_fset_all, exprs)
 colnames(norm_mat) <- adata$var_names
 
+# cytonorm returns the flowframes in the same order as it received them
+cells_per_sample <- flowCore::fsApply(fset_all, function(ff) nrow(exprs(ff)))
+cells_per_norm_sample <- flowCore::fsApply(norm_fset_all, function(ff) nrow(exprs(ff)))
+if (!identical(as.integer(cells_per_sample), as.integer(cells_per_norm_sample))) {
+    stop("Cytonorm returned a different number of cells per sample than it was given.")
+}
+
+# fsApply returns the cells grouped per sample, so restore the original
+# cell order before attaching the obs of the input anndata
+norm_mat <- norm_mat[order(fcs_cell_order(adata, fset_all)), ]
+
 norm_mat <- anndata::AnnData(
     obs = adata$obs[, integer(0)],
     var = adata$var[colnames(norm_mat), integer(0)],

--- a/src/methods/cytonorm_all_controls_to_mid/script.R
+++ b/src/methods/cytonorm_all_controls_to_mid/script.R
@@ -111,6 +111,17 @@ cat("Preparing output anndata\n")
 norm_mat <- flowCore::fsApply(norm_fset_all, exprs)
 colnames(norm_mat) <- adata$var_names
 
+# cytonorm returns the flowframes in the same order as it received them
+cells_per_sample <- flowCore::fsApply(fset_all, function(ff) nrow(exprs(ff)))
+cells_per_norm_sample <- flowCore::fsApply(norm_fset_all, function(ff) nrow(exprs(ff)))
+if (!identical(as.integer(cells_per_sample), as.integer(cells_per_norm_sample))) {
+    stop("Cytonorm returned a different number of cells per sample than it was given.")
+}
+
+# fsApply returns the cells grouped per sample, so restore the original
+# cell order before attaching the obs of the input anndata
+norm_mat <- norm_mat[order(fcs_cell_order(adata, fset_all)), ]
+
 norm_mat <- anndata::AnnData(
     obs = adata$obs[, integer(0)],
     var = adata$var[colnames(norm_mat), integer(0)],

--- a/src/methods/cytonorm_no_controls_to_goal/script.R
+++ b/src/methods/cytonorm_no_controls_to_goal/script.R
@@ -128,6 +128,17 @@ cat("Preparing output anndata\n")
 norm_mat <- flowCore::fsApply(norm_fset_all, exprs)
 colnames(norm_mat) <- adata$var_names
 
+# cytonorm returns the flowframes in the same order as it received them
+cells_per_sample <- flowCore::fsApply(fset_all, function(ff) nrow(exprs(ff)))
+cells_per_norm_sample <- flowCore::fsApply(norm_fset_all, function(ff) nrow(exprs(ff)))
+if (!identical(as.integer(cells_per_sample), as.integer(cells_per_norm_sample))) {
+    stop("Cytonorm returned a different number of cells per sample than it was given.")
+}
+
+# fsApply returns the cells grouped per sample, so restore the original
+# cell order before attaching the obs of the input anndata
+norm_mat <- norm_mat[order(fcs_cell_order(adata, fset_all)), ]
+
 norm_mat <- anndata::AnnData(
     obs = adata$obs[, integer(0)],
     var = adata$var[colnames(norm_mat), integer(0)],

--- a/src/methods/cytonorm_no_controls_to_mid/script.R
+++ b/src/methods/cytonorm_no_controls_to_mid/script.R
@@ -125,6 +125,17 @@ cat("Preparing output anndata\n")
 norm_mat <- flowCore::fsApply(norm_fset_all, exprs)
 colnames(norm_mat) <- adata$var_names
 
+# cytonorm returns the flowframes in the same order as it received them
+cells_per_sample <- flowCore::fsApply(fset_all, function(ff) nrow(exprs(ff)))
+cells_per_norm_sample <- flowCore::fsApply(norm_fset_all, function(ff) nrow(exprs(ff)))
+if (!identical(as.integer(cells_per_sample), as.integer(cells_per_norm_sample))) {
+    stop("Cytonorm returned a different number of cells per sample than it was given.")
+}
+
+# fsApply returns the cells grouped per sample, so restore the original
+# cell order before attaching the obs of the input anndata
+norm_mat <- norm_mat[order(fcs_cell_order(adata, fset_all)), ]
+
 norm_mat <- anndata::AnnData(
     obs = adata$obs[, integer(0)],
     var = adata$var[colnames(norm_mat), integer(0)],

--- a/src/methods/cytonorm_one_control_to_goal/script.R
+++ b/src/methods/cytonorm_one_control_to_goal/script.R
@@ -116,6 +116,17 @@ cat("Preparing output anndata\n")
 norm_mat <- flowCore::fsApply(norm_fset_all, exprs)
 colnames(norm_mat) <- adata$var_names
 
+# cytonorm returns the flowframes in the same order as it received them
+cells_per_sample <- flowCore::fsApply(fset_all, function(ff) nrow(exprs(ff)))
+cells_per_norm_sample <- flowCore::fsApply(norm_fset_all, function(ff) nrow(exprs(ff)))
+if (!identical(as.integer(cells_per_sample), as.integer(cells_per_norm_sample))) {
+    stop("Cytonorm returned a different number of cells per sample than it was given.")
+}
+
+# fsApply returns the cells grouped per sample, so restore the original
+# cell order before attaching the obs of the input anndata
+norm_mat <- norm_mat[order(fcs_cell_order(adata, fset_all)), ]
+
 norm_mat <- anndata::AnnData(
     obs = adata$obs[, integer(0)],
     var = adata$var[colnames(norm_mat), integer(0)],

--- a/src/methods/cytonorm_one_control_to_mid/script.R
+++ b/src/methods/cytonorm_one_control_to_mid/script.R
@@ -113,6 +113,17 @@ cat("Preparing output anndata\n")
 norm_mat <- flowCore::fsApply(norm_fset_all, exprs)
 colnames(norm_mat) <- adata$var_names
 
+# cytonorm returns the flowframes in the same order as it received them
+cells_per_sample <- flowCore::fsApply(fset_all, function(ff) nrow(exprs(ff)))
+cells_per_norm_sample <- flowCore::fsApply(norm_fset_all, function(ff) nrow(exprs(ff)))
+if (!identical(as.integer(cells_per_sample), as.integer(cells_per_norm_sample))) {
+    stop("Cytonorm returned a different number of cells per sample than it was given.")
+}
+
+# fsApply returns the cells grouped per sample, so restore the original
+# cell order before attaching the obs of the input anndata
+norm_mat <- norm_mat[order(fcs_cell_order(adata, fset_all)), ]
+
 norm_mat <- anndata::AnnData(
     obs = adata$obs[, integer(0)],
     var = adata$var[colnames(norm_mat), integer(0)],

--- a/src/methods/gaussnorm/script.R
+++ b/src/methods/gaussnorm/script.R
@@ -44,6 +44,10 @@ for(marker in markers_to_correct){
 # Concatenate all flowFrames in a FlowSet
 integrated_matrix <- fsApply(fset,exprs)
 
+# fsApply returns the cells grouped per sample, so restore the original
+# cell order before attaching the obs of the input anndata
+integrated_matrix <- integrated_matrix[order(fcs_cell_order(adata, fset)), ]
+
 cat("Write output AnnData to file\n")
 output <- anndata::AnnData(
   obs = adata$obs[,integer(0)],

--- a/src/utils/anndata_to_fcs.R
+++ b/src/utils/anndata_to_fcs.R
@@ -112,3 +112,34 @@ anndata_to_fcs <- function(adata, out_dir= NULL, layer_name = 'preprocessed') {
     return(fcs_files)
   }
 }
+
+#' @title Cell order of a FlowSet relative to the AnnData object it came from
+#'
+#' @description `anndata_to_fcs()` creates one flowFrame per sample, so
+#' `flowCore::fsApply(fset, exprs)` returns the cells grouped per sample rather
+#' than in the original cell order of the AnnData object. This function returns
+#' the AnnData row indices in the order in which they appear in the concatenated
+#' matrix, so `mat[order(fcs_cell_order(adata, fset)), ]` restores the original
+#' cell order. If the cells were already grouped per sample, this is a no-op.
+#'
+#' @param adata AnnData object the FlowSet was created from.
+#' @param fset FlowSet whose sample names determine the concatenation order.
+#' @return An integer vector with one entry per cell in `adata`.
+fcs_cell_order <- function(adata, fset) {
+  samples <- as.character(adata$obs$sample)
+
+  cell_order <- unlist(lapply(
+    flowCore::sampleNames(fset),
+    function(sample) which(samples == sample)
+  ))
+
+  if (length(cell_order) != length(samples)) {
+    stop(
+      "The FlowSet does not contain the same cells as the AnnData object: ",
+      length(cell_order), " cells in the FlowSet, ",
+      length(samples), " cells in the AnnData object."
+    )
+  }
+
+  cell_order
+}


### PR DESCRIPTION
## Describe your changes

`anndata_to_fcs()` builds one flowFrame per sample, so `flowCore::fsApply(fset, exprs)` gives the cells back **grouped per sample**. `gaussnorm` and the six `cytonorm_*` methods then attach that matrix to the obs of the input AnnData, which is in the *original* cell order:

```r
integrated_matrix <- fsApply(fset, exprs)     # grouped per sample

output <- anndata::AnnData(
  obs = adata$obs[, integer(0)],              # original cell order
  layers = list(integrated = integrated_matrix)
)
```

As long as the cells in the input happen to be contiguous per sample and in first-appearance order, the two orders coincide and everything is fine -- which is presumably why this hasn't shown up. But nothing in `file_censored_split1.yaml` guarantees it, and if it ever doesn't hold, every cell gets paired with another cell's expression values. Silently. It would look like a badly performing method rather than a bug.

`batchadjust_*` already guards against this explicitly with its `Original_ID` column; this PR does the equivalent for the other two families:

* Adds `fcs_cell_order()` to `src/utils/anndata_to_fcs.R`, which returns the AnnData row indices in the order the concatenated matrix has them, looked up by the FlowSet's own sample names. It errors out if the FlowSet doesn't cover exactly the cells of the AnnData object.
* Uses it in `methods/gaussnorm` and in the six `methods/cytonorm_*` variants.
* In the cytonorm methods, also checks that `CytoNorm.normalize()` returned the same number of cells per sample as it was given, so the assumption that it preserves frame order fails loudly rather than silently.

**This is a no-op when the current implicit assumption holds** -- `order(fcs_cell_order(...))` is the identity permutation for sample-contiguous input -- so it should not change any score unless there was a real problem to begin with. That also makes it a cheap way to find out whether there was one: if a score moves, the ordering was wrong.

I haven't been able to run `viash test` for these locally, so CI and a test benchmark run are the real check here.

Found while reviewing the task ahead of the next full benchmark run -- see also the sibling PRs.

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!
