### PR TITLE
Point the full run scripts at build/main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,3 +240,6 @@
 
 * Update flowsom mapping similarity so we subset to just markers to correct, and lisi to remove control samples
   and unlabelled cells (PR #119).
+
+* Point `scripts/run_benchmark/wehi_hpc/run_full_hpc.sh` at `build/main` instead of
+  `build/update_ilisi`, and label the seqera full run as `full` instead of `test_subset` (PR #129).

--- a/scripts/run_benchmark/run_full_seqeracloud.sh
+++ b/scripts/run_benchmark/run_full_seqeracloud.sh
@@ -28,4 +28,4 @@ tw launch https://github.com/openproblems-bio/task_cyto_batch_integration.git \
   --params-file /tmp/params.yaml \
   --entry-name auto \
   --config common/nextflow_helpers/labels_tw.config \
-  --labels task_cyto_batch_integration,test_subset
+  --labels task_cyto_batch_integration,full

--- a/scripts/run_benchmark/wehi_hpc/run_full_hpc.sh
+++ b/scripts/run_benchmark/wehi_hpc/run_full_hpc.sh
@@ -21,7 +21,7 @@ publish_dir: "$publish_dir"
 HERE
 
 tw launch https://github.com/openproblems-bio/task_cyto_batch_integration.git \
-  --revision build/update_ilisi \
+  --revision build/main \
   --pull-latest \
   --main-script target/nextflow/workflows/run_benchmark/main.nf \
   --workspace 80689470953249 \


### PR DESCRIPTION
## Describe your changes

Two leftovers in the launch scripts that would bite on the next full run:

* `scripts/run_benchmark/wehi_hpc/run_full_hpc.sh` still passes `--revision build/update_ilisi`, so a full HPC run would launch the build of a feature branch rather than `build/main`.
* `scripts/run_benchmark/run_full_seqeracloud.sh` tags the run with `--labels task_cyto_batch_integration,test_subset`, which makes full runs show up as test runs on Seqera.

Happy to be told the `build/update_ilisi` pin was deliberate and should stay for now -- just flagging it because it is easy to miss.

Found while reviewing the task ahead of the next full benchmark run -- see also the sibling PRs.

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!
