### PR TITLE
Write metric_ids and metric_values as lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,3 +240,6 @@
 
 * Update flowsom mapping similarity so we subset to just markers to correct, and lisi to remove control samples
   and unlabelled cells (PR #119).
+
+* Fix `average_batch_r2` and `flowsom_mapping_similarity` writing `metric_ids` and `metric_values`
+  as scalars instead of lists, as required by `file_score.yaml` (PR #130).

--- a/src/metrics/average_batch_r2/script.py
+++ b/src/metrics/average_batch_r2/script.py
@@ -84,8 +84,8 @@ output = ad.AnnData(
     uns={
         "dataset_id": integrated_s1.uns["dataset_id"],
         "method_id": integrated_s1.uns["method_id"],
-        "metric_ids": "average_batch_r2_ct",
-        "metric_values": average_batch_r2_ct,
+        "metric_ids": ["average_batch_r2_ct"],
+        "metric_values": [average_batch_r2_ct],
         "r2_collection_ct": r2_collection_ct,
     }
 )

--- a/src/metrics/flowsom_mapping_similarity/script.R
+++ b/src/metrics/flowsom_mapping_similarity/script.R
@@ -144,8 +144,8 @@ output <- anndata::AnnData(
   uns = list(
     dataset_id = integrated_s1$uns$dataset_id,
     method_id = integrated_s1$uns$method_id,
-    metric_ids = "flowsom_mean_mapping_similarity",
-    metric_values = fs_mapping_similarity_avg,
+    metric_ids = list("flowsom_mean_mapping_similarity"),
+    metric_values = list(fs_mapping_similarity_avg),
     fsom_absdiff_by_donor_refsplit = fsom_absdiff_by_donor_refsplit,
     fsom_parameters = list(
       "xdim" = grid_xdim,


### PR DESCRIPTION
## Describe your changes

`file_score.yaml` declares both `metric_ids` and `metric_values` as `multiple: true`, and `common/schemas/results_v4/results.json` types the corresponding `metric_names`/`metric_values` as arrays. Two metrics write them as scalars instead:

* `metrics/average_batch_r2` -- `"metric_ids": "average_batch_r2_ct"`, `"metric_values": average_batch_r2_ct`
* `metrics/flowsom_mapping_similarity` -- `metric_ids = "flowsom_mean_mapping_similarity"`, `metric_values = fs_mapping_similarity_avg` (a length-1 R vector, which reticulate hands to anndata as a plain Python string/float)

The other four metric components already write lists. This PR makes these two do the same, so the score files are consistent and the results schema holds for every component.

Found while reviewing the task ahead of the next full benchmark run -- see also the sibling PRs.

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!
